### PR TITLE
Fix compile error w/rust v1.79.0 related to multiple inheritance of Samplable trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub trait AdditivelyHomomorphicEncryptionKey<const PLAINTEXT_SPACE_SCALAR_LIMBS: usize>:
     PartialEq + Clone + Debug + Eq
 {
-    type PlaintextSpaceGroupElement: KnownOrderScalar<PLAINTEXT_SPACE_SCALAR_LIMBS> + Samplable;
+    type PlaintextSpaceGroupElement: KnownOrderScalar<PLAINTEXT_SPACE_SCALAR_LIMBS>;
     type RandomnessSpaceGroupElement: GroupElement + Samplable;
     type CiphertextSpaceGroupElement: GroupElement;
 


### PR DESCRIPTION
As trait group::KnownOrderScalar<..> already inherits Samplable, PlaintextSpaceGroupElement does not need to inherit Samplable explicitly.

This corrects the unsatisfied trait bound error reported by rust v1.79.0.